### PR TITLE
GetOneQuery extension method overload with OrderBy parameter added.

### DIFF
--- a/Source/Pragmatic.EntityFramework.Tests.Integration/GetOneQueryHandlerTests.cs
+++ b/Source/Pragmatic.EntityFramework.Tests.Integration/GetOneQueryHandlerTests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using Pragmatic.EntityFramework.Interaction.StandardQueries;
 using Pragmatic.EntityFramework.Tests.Integration.Data;
+using Pragmatic.Interaction;
 using Pragmatic.Interaction.StandardQueries;
 using SwissKnife;
 
@@ -9,25 +10,52 @@ namespace Pragmatic.EntityFramework.Tests.Integration
 {
     // ReSharper disable InconsistentNaming
     [TestFixture]
-    public class GetOneQueryHandlerTests // TODO-IG: Define integration tests in a persistence independent way and test them for all persistences.
+    public class GetOneQueryHandlerTests // TODO-IG: Define integration tests in a persistence independent way and test them for all persistence's.
     {
         [Test]
-        public void Returns_person_by_name()
+        public void Returns_person_by_name_ordered_by_age()
         {
             string name = Guid.NewGuid().ToString();
+            int age = 20;
 
             var context = new PragmaticDbContext();
-            context.Persons.Add(new Person() {Name = name});
+            context.Persons.Add(new Person() { Name = name, Age = age });
+            context.Persons.Add(new Person() { Name = name, Age = age + 1 });
             context.SaveChanges();
 
             Option<Person> person = new GetOneQueryHandler<Person>(new PragmaticDbContext())
                 .Execute(new GetOneQuery<Person>()
                 {
-                    Criteria = persons => persons.Name == name
+                    Criteria = persons => persons.Name == name,
+                    OrderBy = new OrderBy<Person>(persons => persons.Age)
                 });
 
             Assert.IsTrue(person.IsSome);
             Assert.AreEqual(name, person.Value.Name);
+            Assert.AreEqual(age, person.Value.Age);
+        }
+
+        [Test]
+        public void Returns_person_by_name_ordered_by_age_descending()
+        {
+            string name = Guid.NewGuid().ToString();
+            int age = 20;
+
+            var context = new PragmaticDbContext();
+            context.Persons.Add(new Person() { Name = name, Age = age });
+            context.Persons.Add(new Person() { Name = name, Age = age + 1 });
+            context.SaveChanges();
+
+            Option<Person> person = new GetOneQueryHandler<Person>(new PragmaticDbContext())
+                .Execute(new GetOneQuery<Person>()
+                {
+                    Criteria = persons => persons.Name == name,
+                    OrderBy = new OrderBy<Person>(persons => persons.Age, OrderByDirection.Descending)
+                });
+
+            Assert.IsTrue(person.IsSome);
+            Assert.AreEqual(name, person.Value.Name);
+            Assert.AreEqual(age + 1, person.Value.Age);
         }
     }
     // ReSharper restore InconsistentNaming

--- a/Source/Pragmatic.EntityFramework/Interaction/StandardQueries/GetOneQueryHandler.cs
+++ b/Source/Pragmatic.EntityFramework/Interaction/StandardQueries/GetOneQueryHandler.cs
@@ -21,7 +21,7 @@ namespace Pragmatic.EntityFramework.Interaction.StandardQueries
             // TODO-IG: Good point. Current semantic is to return the first one! Therefore the query should be renamed to GetFirst.
             //          GetOne can remain, but it should throw exception if there are more than one. Or we can remove it completely.
             //return queryable.OrderBy(query.OrderBy).Where(query.Criteria).SingleOrDefault();
-            return queryable.OrderBy(query.OrderBy).Where(query.Criteria).FirstOrDefault();
+            return queryable.OrderByWithExpressionTransform(query.OrderBy).Where(query.Criteria).FirstOrDefault();
         }
     }
 }

--- a/Source/Pragmatic/Interaction/QueryExecutorExtensions.cs
+++ b/Source/Pragmatic/Interaction/QueryExecutorExtensions.cs
@@ -31,6 +31,14 @@ namespace Pragmatic.Interaction
             return queryExecutor.Execute(new GetOneQuery<T> { Criteria = criteria });
         }
 
+        public static Option<T> GetOne<T>(this QueryExecutor queryExecutor, Expression<Func<T, bool>> criteria, OrderBy<T> orderBy) where T : class
+        {
+            Argument.IsNotNull(queryExecutor, "queryExecutor");
+            Argument.IsNotNull(criteria, "criteria");
+
+            return queryExecutor.Execute(new GetOneQuery<T> { Criteria = criteria, OrderBy = orderBy });
+        }
+
         public static IPagedEnumerable<T> GetAll<T>(this QueryExecutor queryExecutor) where T : class
         {
             Argument.IsNotNull(queryExecutor, "queryExecutor");

--- a/Source/Pragmatic/Interaction/QueryExecutorExtensions.cs
+++ b/Source/Pragmatic/Interaction/QueryExecutorExtensions.cs
@@ -35,6 +35,7 @@ namespace Pragmatic.Interaction
         {
             Argument.IsNotNull(queryExecutor, "queryExecutor");
             Argument.IsNotNull(criteria, "criteria");
+            Argument.IsNotNull(orderBy, "orderBy");
 
             return queryExecutor.Execute(new GetOneQuery<T> { Criteria = criteria, OrderBy = orderBy });
         }


### PR DESCRIPTION
To avoid using GetAll with OrderBy and Paging(1,1) I added second extension method for GetOneQuery, with integration test. 
